### PR TITLE
Implement env loader and $$ helper

### DIFF
--- a/runtime/cli.js
+++ b/runtime/cli.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import readline from 'readline';
-import { createRuntime } from './index.js';
+import { createRuntime, loadEnvironment, loadBlueprint } from './index.js';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -17,7 +17,14 @@ async function main() {
     process.exit(1);
   }
   const initialProcess = await loadProcess(soulDir);
-  const runtime = createRuntime({ initialProcess, soulName: path.basename(soulDir) });
+  const env = await loadEnvironment(soulDir);
+  const blueprint = await loadBlueprint(soulDir, env);
+  const runtime = createRuntime({
+    initialProcess,
+    soulName: path.basename(soulDir),
+    env,
+    blueprint
+  });
   runtime.on('says', ({ content }) => {
     console.log(path.basename(soulDir), 'says:', content);
   });

--- a/runtime/test/env-vars.test.js
+++ b/runtime/test/env-vars.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import * as ts from 'typescript';
+import { createRuntime, loadEnvironment, loadBlueprint, ChatMessageRoleEnum, $$ } from '../index.js';
+
+const soulDir = path.resolve('../souls/env-vars');
+
+test('blueprint markdown is expanded using env vars', async () => {
+  const env = await loadEnvironment(soulDir);
+  const blueprintPath = path.resolve('../souls/env-vars/soul/{{ENTITY_NAME}}.md');
+  const raw = await fs.readFile(blueprintPath, 'utf8');
+  globalThis.soul = { env };
+  const expected = $$(raw);
+  delete globalThis.soul;
+
+  const loaded = await loadBlueprint(soulDir, env);
+  assert.equal(loaded, expected);
+});
+
+async function compileProcess() {
+  const tsPath = path.resolve('../souls/env-vars/soul/initialProcess.ts');
+  const tsSource = await fs.readFile(tsPath, 'utf8');
+  const runtimeUrl = pathToFileURL(path.resolve('index.js')).href;
+  const replaced = tsSource.replace('@opensouls/engine', runtimeUrl);
+  const jsSource = ts.transpileModule(replaced, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 }
+  }).outputText;
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'env-'));
+  const jsPath = path.join(tmpDir, 'initialProcess.js');
+  await fs.writeFile(jsPath, jsSource);
+  return pathToFileURL(jsPath).href;
+}
+
+test('environment variables are loaded and templated', async () => {
+  const env = await loadEnvironment(soulDir);
+  const blueprint = await loadBlueprint(soulDir, env);
+  const procUrl = await compileProcess();
+  const { default: initialProcess } = await import(procUrl);
+  const runtime = createRuntime({ initialProcess, soulName: 'Env', env, blueprint });
+
+  assert.equal(runtime.workingMemory.memories.length, 1);
+  const [systemBefore] = runtime.workingMemory.memories;
+  assert.equal(systemBefore.content, blueprint);
+
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+
+  await runtime.dispatch({ action: 'said', name: 'User', content: 'hi' });
+
+  assert.deepEqual(says, ['I like alice, pumpkins.']);
+  assert.equal(runtime.workingMemory.memories.length, 2);
+  const [system, user] = runtime.workingMemory.memories;
+  assert.equal(system.role, ChatMessageRoleEnum.System);
+  assert.ok(system.content.includes('Bob'));
+  assert.equal(user.role, ChatMessageRoleEnum.User);
+});


### PR DESCRIPTION
## Summary
- add environment variable loader and blueprint templating
- expose global `$$` and `soul.env`
- update runtime CLI to load env and blueprint
- test environment variable interpolation
- test blueprint interpolation from `{{ENTITY_NAME}}.md`

## Testing
- `cd runtime && npm test`
