### PR TITLE
Implement event scheduling queue

### DIFF
--- a/runtime-implementation-plan.md
+++ b/runtime-implementation-plan.md
@@ -2,7 +2,7 @@
 
 This document outlines the steps required to add missing functionality to the local runtime. The milestones are based on the gaps identified in the documentation and example souls under `souls/`.
 
-## Milestone 1 – Environment Variable Templating
+## Milestone 1 – Environment Variable Templating *(Completed)*
 
 * Create a configuration loader that reads `/soul/default.env.ts` for each soul.
 * Expose the parsed values via `soul.env`.

--- a/runtime/test/schedule-events.test.js
+++ b/runtime/test/schedule-events.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRuntime, useActions } from '../index.js';
+
+const handlePoke = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  speak('poke event');
+  return workingMemory;
+};
+
+let scheduledId;
+const scheduler = async ({ workingMemory }) => {
+  const { scheduleEvent } = useActions();
+  scheduledId = scheduleEvent({ in: 0.05, perception: { action: 'poke', content: 'poke', name: 'Test' }, process: handlePoke });
+  return workingMemory;
+};
+
+test('scheduled event executes after delay', async () => {
+  const runtime = createRuntime({ initialProcess: scheduler, soulName: 'Test' });
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+
+  await runtime.dispatch({ action: 'start', content: 'go', name: 'Tester' });
+  assert.equal(runtime.getPendingEvents().length, 1);
+
+  await new Promise(res => setTimeout(res, 80));
+
+  assert.equal(runtime.getPendingEvents().length, 0);
+  assert.deepEqual(says, ['poke event']);
+});
+
+test('scheduled event can be cancelled', async () => {
+  const runtime = createRuntime({ initialProcess: scheduler, soulName: 'Test' });
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+
+  await runtime.dispatch({ action: 'start', content: 'go', name: 'Tester' });
+  runtime.cancelScheduledEvent(scheduledId);
+  assert.equal(runtime.getPendingEvents().length, 0);
+
+  await new Promise(res => setTimeout(res, 80));
+
+  assert.deepEqual(says, []);
+});


### PR DESCRIPTION
## Summary
- mark milestone 1 complete in `runtime-implementation-plan.md`
- implement queue-based event scheduling with cancel support
- expose pending scheduled events via `useProcessManager`
- add tests for scheduling and cancellation

## Testing
- `cd runtime && npm test`