### PR TITLE
Implement previous mental process tracking

### DIFF
--- a/runtime-implementation-plan.md
+++ b/runtime-implementation-plan.md
@@ -9,7 +9,7 @@ This document outlines the steps required to add missing functionality to the lo
 * Implement the `$$(text)` helper to perform `{{variable}}` interpolation using `soul.env`.
 * Apply template expansion when loading blueprint markdown files (e.g. `{{entityName}}.md`).
 
-## Milestone 2 – Event Scheduling and Management
+## Milestone 2 – Event Scheduling and Management *(Completed)*
 
 * Replace the simple `setTimeout` logic with a queue of pending events.
 * Generate a unique ID for each scheduled event and return it from `scheduleEvent`.

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -197,6 +197,7 @@ export class Runtime {
     this.env = env;
     this.currentProcess = initialProcess;
     this.nextProcess = null;
+    this.previousProcess = undefined;
     this.invocationCount = 0;
     this.emitter = new EventEmitter();
     this.workingMemory = new WorkingMemory({ soulName });
@@ -234,6 +235,7 @@ export class Runtime {
   useProcessManager() {
     const runtime = this;
     return {
+      previousMentalProcess: runtime.previousProcess,
       invocationCount: runtime.invocationCount,
       pendingScheduledEvents: runtime.getPendingEvents(),
       cancelScheduledEvent(id) {
@@ -268,6 +270,7 @@ export class Runtime {
       const result = await proc({ workingMemory: this.workingMemory });
       this.invocationCount += 1;
       if (this.nextProcess) {
+        this.previousProcess = this.currentProcess;
         this.currentProcess = this.nextProcess;
         this.nextProcess = null;
         this.invocationCount = 0;

--- a/runtime/test/process-manager.test.js
+++ b/runtime/test/process-manager.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRuntime, useActions, useProcessManager } from '../index.js';
+
+const processB = async ({ workingMemory }) => {
+  const { previousMentalProcess, invocationCount } = useProcessManager();
+  const { speak } = useActions();
+  speak(`B ${invocationCount} prev:${previousMentalProcess === processA}`);
+  return workingMemory;
+};
+
+const processA = async ({ workingMemory }) => {
+  const { invocationCount, setNextProcess } = useProcessManager();
+  const { speak } = useActions();
+  speak(`A ${invocationCount}`);
+  if (invocationCount === 0) {
+    setNextProcess(processB);
+  }
+  return workingMemory;
+};
+
+test('previousMentalProcess and invocationCount are tracked', async () => {
+  const runtime = createRuntime({ initialProcess: processA, soulName: 'Test' });
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+
+  assert.equal(runtime.previousProcess, undefined);
+
+  await runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  assert.equal(runtime.previousProcess, processA);
+  assert.equal(runtime.currentProcess, processB);
+  assert.equal(runtime.invocationCount, 0);
+
+  await runtime.dispatch({ action: 'cont', name: 'User', content: 'again' });
+  assert.equal(runtime.previousProcess, processA);
+  assert.equal(runtime.currentProcess, processB);
+  assert.equal(runtime.invocationCount, 1);
+
+  await runtime.dispatch({ action: 'cont', name: 'User', content: 'again' });
+  assert.equal(runtime.previousProcess, processA);
+  assert.equal(runtime.currentProcess, processB);
+  assert.equal(runtime.invocationCount, 2);
+
+  assert.deepEqual(says, ['A 0', 'B 0 prev:true', 'B 1 prev:true']);
+});


### PR DESCRIPTION
## Summary
- implement `previousMentalProcess` tracking in runtime
- expose the value via `useProcessManager`
- update runtime plan to mark milestone 2 complete
- add tests for `previousMentalProcess`

## Testing
- `cd runtime && npm test`