### PR TITLE
Implement persistence APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
 .DS_Store
+runtime/**/.store/
+

--- a/runtime-implementation-plan.md
+++ b/runtime-implementation-plan.md
@@ -23,7 +23,7 @@ This document outlines the steps required to add missing functionality to the lo
 * Surface `pendingScheduledEvents` and `cancelScheduledEvent` through `useProcessManager`.
 * Update `wait()` to be a promise-based sleep helper used by processes.
 
-## Milestone 4 – Perception Utilities
+## Milestone 4 – Perception Utilities *(Completed)*
 
 * Record the perception that triggered the current process as `invokingPerception`.
 * Keep a list of new perceptions that arrive while a process is running (`pendingPerceptions`).

--- a/runtime/cli.js
+++ b/runtime/cli.js
@@ -23,7 +23,8 @@ async function main() {
     initialProcess,
     soulName: path.basename(soulDir),
     env,
-    blueprint
+    blueprint,
+    storeDir: path.join(soulDir, '.store')
   });
   runtime.on('says', ({ content }) => {
     console.log(path.basename(soulDir), 'says:', content);

--- a/runtime/stores/localStore.js
+++ b/runtime/stores/localStore.js
@@ -1,0 +1,82 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+function tokenize(text) {
+  return text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function similarity(aTokens, bTokens) {
+  const setA = new Set(aTokens);
+  const setB = new Set(bTokens);
+  const intersection = [...setA].filter(x => setB.has(x)).length;
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export class LocalStore {
+  constructor(file) {
+    this.file = file;
+    this.data = {};
+    this.loaded = false;
+  }
+
+  async _load() {
+    if (this.loaded) return;
+    try {
+      const raw = await fs.readFile(this.file, 'utf8');
+      this.data = JSON.parse(raw);
+    } catch {
+      this.data = {};
+    }
+    this.loaded = true;
+  }
+
+  async _save() {
+    await fs.mkdir(path.dirname(this.file), { recursive: true });
+    await fs.writeFile(this.file, JSON.stringify(this.data, null, 2));
+  }
+
+  createEmbedding(content) {
+    return tokenize(String(content));
+  }
+
+  async fetch(key, opts = {}) {
+    await this._load();
+    const entry = this.data[key];
+    if (!entry) return undefined;
+    if (opts.includeMetadata) {
+      return { content: entry.content, metadata: entry.metadata };
+    }
+    return entry.content;
+  }
+
+  async set(key, content, metadata) {
+    await this._load();
+    this.data[key] = {
+      content,
+      metadata,
+      embedding: this.createEmbedding(content)
+    };
+    await this._save();
+  }
+
+  async remove(key) {
+    await this._load();
+    delete this.data[key];
+    await this._save();
+  }
+
+  async search(query, { minSimilarity = 0 } = {}) {
+    await this._load();
+    const queryEmb = this.createEmbedding(query);
+    const results = [];
+    for (const [key, entry] of Object.entries(this.data)) {
+      const sim = similarity(queryEmb, entry.embedding || []);
+      if (sim >= minSimilarity) {
+        results.push({ key, content: entry.content, similarity: sim, metadata: entry.metadata });
+      }
+    }
+    results.sort((a, b) => b.similarity - a.similarity);
+    return results;
+  }
+}

--- a/runtime/test/soul-memory.test.js
+++ b/runtime/test/soul-memory.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRuntime, useActions, useSoulMemory } from '../index.js';
+
+const proc = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  const mem = useSoulMemory('flag', false);
+  speak(String(mem.current));
+  mem.current = true;
+  return workingMemory;
+};
+
+test('useSoulMemory persists across invocations', async () => {
+  const runtime = createRuntime({ initialProcess: proc, soulName: 'MemTest' });
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+  await runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  await runtime.dispatch({ action: 'again', name: 'User', content: 'hi' });
+  assert.deepEqual(says, ['false', 'true']);
+});

--- a/runtime/test/soul-store.test.js
+++ b/runtime/test/soul-store.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { createRuntime, useActions, useSoulStore } from '../index.js';
+
+const proc = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  const store = useSoulStore();
+  const count = (await store.fetch('count')) || 0;
+  await store.set('count', count + 1);
+  const updated = await store.fetch('count');
+  speak(String(updated));
+  return workingMemory;
+};
+
+test('useSoulStore persists to disk', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'store-'));
+  const runtime1 = createRuntime({ initialProcess: proc, soulName: 'Store', storeDir: dir });
+  const says1 = [];
+  runtime1.on('says', ({ content }) => says1.push(content));
+  await runtime1.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  assert.deepEqual(says1, ['1']);
+
+  const runtime2 = createRuntime({ initialProcess: proc, soulName: 'Store', storeDir: dir });
+  const says2 = [];
+  runtime2.on('says', ({ content }) => says2.push(content));
+  await runtime2.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  assert.deepEqual(says2, ['2']);
+});
+


### PR DESCRIPTION
## Summary
- mark Milestone 4 as completed
- add LocalStore utility
- add soul memory & store hooks to runtime
- persist store data via CLI option
- ignore runtime store data
- test soul memory and soul store functionality

## Testing
- `cd runtime && npm test`