### PR TITLE
Implement runtime subprocess support

### DIFF
--- a/runtime-implementation-plan.md
+++ b/runtime-implementation-plan.md
@@ -29,7 +29,7 @@ This document outlines the steps required to add missing functionality to the lo
 * Keep a list of new perceptions that arrive while a process is running (`pendingPerceptions`).
 * Implement a `usePerceptions` hook so processes can access this information.
 
-## Milestone 5 – Persistence APIs
+## Milestone 5 – Persistence APIs *(Completed)*
 
 * Implement `useSoulStore` as a persistent key–value store with optional vector search.
 * Provide `useSoulMemory`, `useBlueprintStore` and `useOrganizationStore` for scoped persistence.

--- a/runtime/cli.js
+++ b/runtime/cli.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import readline from 'readline';
-import { createRuntime, loadEnvironment, loadBlueprint } from './index.js';
+import { createRuntime, loadEnvironment, loadBlueprint, loadSubprocesses } from './index.js';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -17,10 +17,12 @@ async function main() {
     process.exit(1);
   }
   const initialProcess = await loadProcess(soulDir);
+  const subprocesses = await loadSubprocesses(soulDir);
   const env = await loadEnvironment(soulDir);
   const blueprint = await loadBlueprint(soulDir, env);
   const runtime = createRuntime({
     initialProcess,
+    subprocesses,
     soulName: path.basename(soulDir),
     env,
     blueprint,

--- a/runtime/test/subprocesses.test.js
+++ b/runtime/test/subprocesses.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRuntime, useActions, useProcessManager } from '../index.js';
+
+const main = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  speak('main');
+  return workingMemory;
+};
+
+const sub1 = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  speak('sub1');
+  return workingMemory;
+};
+
+test('subprocess runs after process', async () => {
+  const runtime = createRuntime({ initialProcess: main, soulName: 'Sub', subprocesses: [sub1] });
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+  await runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  await new Promise(res => setTimeout(res, 10));
+  assert.deepEqual(says, ['main', 'sub1']);
+});
+
+const waitSub = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  const { wait } = useProcessManager();
+  await wait(20);
+  speak('waited');
+  return workingMemory;
+};
+
+const sub2 = async ({ workingMemory }) => {
+  const { speak } = useActions();
+  speak('sub2');
+  return workingMemory;
+};
+
+test('subprocess chain stops on new perception', async () => {
+  const runtime = createRuntime({ initialProcess: main, soulName: 'Sub', subprocesses: [waitSub, sub2] });
+  const says = [];
+  runtime.on('says', ({ content }) => says.push(content));
+  const first = runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  setTimeout(() => runtime.dispatch({ action: 'next', name: 'User', content: 'yo' }), 10);
+  await first;
+  await new Promise(res => setTimeout(res, 50));
+  assert.deepEqual(says, ['main', 'waited', 'main', 'waited', 'sub2']);
+});


### PR DESCRIPTION
## Summary
- mark persistence milestone completed in runtime-implementation-plan
- load subprocesses in CLI and runtime
- execute subprocesses asynchronously in Runtime
- abort and queue subprocess execution when new perceptions arrive
- add tests for subprocess behaviour

## Testing
- `cd runtime && npm test`