### PR TITLE
Switch docs to local runtime

### DIFF
--- a/demos/discord/food-critic/README.md
+++ b/demos/discord/food-critic/README.md
@@ -15,7 +15,7 @@ FoodCritic is a food critic who gives great reviews about absolutely any kind of
 Run this inside the `food-critic` directory:
 
 ```bash
-npx soul-engine dev
+node ../../../runtime/cli.js .
 ```
 
 Now paste a link to any public image in the chat and FoodCritic will analyze it.

--- a/demos/discord/schmoozie-discord-group-conversations/README.md
+++ b/demos/discord/schmoozie-discord-group-conversations/README.md
@@ -15,7 +15,7 @@ Schmoozie is a Discord bot that can take part in lively group conversations and 
 Simply go to the root directory and run:
 
 ```bash
-npx soul-engine dev
+node ../../../runtime/cli.js .
 ```
 
 ## 🎮 Running in Development with Discord

--- a/demos/nextjs/code-monkey/README.md
+++ b/demos/nextjs/code-monkey/README.md
@@ -17,7 +17,7 @@ Code Monkey can help you quickly create a draft version of a code snippet, techn
 Simply go to the root directory and run:
 
 ```bash
-npx soul-engine dev
+node ../../../runtime/cli.js .
 ```
 
 ## 🌎 Running the webapp

--- a/demos/nextjs/cranky/README.md
+++ b/demos/nextjs/cranky/README.md
@@ -17,7 +17,7 @@ Cranky is an insufferably sarcastic, ill-tempered, irritable person trapped insi
 Simply go to the root directory and run:
 
 ```bash
-npx soul-engine dev
+node ../../../runtime/cli.js .
 ```
 
 ## 🌎 Running the webapp

--- a/demos/nextjs/reggie-is-regex/README.md
+++ b/demos/nextjs/reggie-is-regex/README.md
@@ -9,7 +9,7 @@ The [soul](./soul/) directory contains reggie himself.
 The [web](./web/) directory contains a nextjs app which has a [SoulProvider](./web/src/components/SoulProvider.tsx) to hook up to Reggie.
 
 Getting started:
-`npx soul-engine dev` in this directory.
+`node ../../../runtime/cli.js .` in this directory.
 
 Follow the [README](./web/README.md) in the web directory
 and then:

--- a/demos/telegram/graham/README.md
+++ b/demos/telegram/graham/README.md
@@ -15,7 +15,7 @@ Graham is an example soul that can chat with you on Telegram.
 Simply go to the root directory and run:
 
 ```bash
-npx soul-engine dev
+node ../../../runtime/cli.js .
 ```
 
 ## 🎮 Running in Development with Telegram

--- a/docs/pages/blueprints/hooks/useTool.mdx
+++ b/docs/pages/blueprints/hooks/useTool.mdx
@@ -21,6 +21,7 @@ soul.registerTool("visit", async ({ url }: { url: string }) => {
   }
 });
 ```
+The `SOUL_ENGINE_TOKEN` variable is only required when connecting to the hosted Soul Engine.
 
 
 ## Example Blueprint Code

--- a/docs/pages/getting-started/connect-external-app.mdx
+++ b/docs/pages/getting-started/connect-external-app.mdx
@@ -23,10 +23,10 @@ As a result you'll get a project folder that looks like this:
 
 ![](/images/guide/connect-external-app/01-init-soul.webp)
 
-Graham's blueprint doesn't exist in the Soul Engine yet, so let's run `soul-engine dev` to upload the code and also start the local development server:
+Graham's blueprint doesn't exist in the Soul Engine yet, so let's run the local runtime to upload the code and start the debugger:
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```
 
 If everything is working correctly, a new browser window should open with the Soul Engine debugger. You should also see confirmation that the code was uploaded in your terminal:
@@ -123,8 +123,9 @@ TELEGRAM_TOKEN="the token you received from BotFather"
 SOUL_ENGINE_BLUEPRINT="graham"
 SOUL_ENGINE_ORGANIZATION="add your Soul Engine organization id here"
 ```
+These `SOUL_ENGINE_*` variables are only needed when you connect to the hosted Soul Engine.
 
-Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `soul-engine dev`. You'll see a link there - your organization id is the first part of the path after `/chats`:
+Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `node ../../runtime/cli.js .`. You'll see a link there - your organization id is the first part of the path after `/chats`:
 
 ![](/images/guide/connect-external-app/08-url-parts.webp)
 
@@ -163,7 +164,7 @@ async function connectToSoulEngine(telegram: Telegraf<Context>) {
 // ...
 ```
 
-Find the terminal that's running your Telegram app (attention: this is not the one running `soul-engine dev`!). Stop the app by pressing `Ctrl+C` in the terminal, and then run it again with `npx tsx telegram/index.ts`. Now, when you send a message to the Graham, it should be his soul that replies:
+Find the terminal that's running your Telegram app (attention: this is not the one running `node ../../runtime/cli.js .`!). Stop the app by pressing `Ctrl+C` in the terminal, and then run it again with `npx tsx telegram/index.ts`. Now, when you send a message to the Graham, it should be his soul that replies:
 
 ![](/images/guide/connect-external-app/09-soul-connected.webp)
 

--- a/docs/pages/getting-started/modify-example-soul.mdx
+++ b/docs/pages/getting-started/modify-example-soul.mdx
@@ -6,12 +6,12 @@ As an introduction to the soul development process with the Soul Engine, we'll m
 
 ## Preparation
 
-Make sure the `soul-engine dev` process is running so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
+Make sure the local runtime (`node ../../runtime/cli.js .`) is running so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
 
 ```mermaid
 flowchart LR
 
-yourComputer("Your computer running \n soul-engine dev")
+yourComputer("Your computer running \n node ../../runtime/cli.js .")
 soulEngine("Soul Engine servers\n\n(Samantha is running here)")
 debugger("Debugger UI \n\n (The interface where you're \n interacting with Samantha)")
 
@@ -67,7 +67,7 @@ Now click the "Rewind" button that's right above your last message and try sayin
 
 ## Samantha doesn't need your computer to run
 
-Stop the execution of the `soul-engine dev` process by pressing `Ctrl + C` in the terminal:
+Stop the execution of the `node ../../runtime/cli.js .` process by pressing `Ctrl + C` in the terminal:
 
 ![](/images/guide/modify-example-soul/05-terminal.png)
 
@@ -75,6 +75,6 @@ Now try speaking to Samantha again. You'll see that she continues to answer in t
 
 ![](/images/guide/modify-example-soul/06-samantha-is-alive.png)
 
-Samantha's soul has been running on the Soul Engine servers since you ran `soul-engine dev` for the first time. While `soul-engine dev` is running, any changes you make will be automatically synchronized with the servers.
+Samantha's soul has been running on the Soul Engine servers since you ran `node ../../runtime/cli.js .` for the first time. While the process is running, any changes you make will be automatically synchronized with the servers.
 
 Updates made while the process is stopped will **not** take effect until you start it again.

--- a/docs/pages/getting-started/run-example-soul.mdx
+++ b/docs/pages/getting-started/run-example-soul.mdx
@@ -10,12 +10,12 @@ Follow the [quick start guide](/) to run the Samantha soul. If everything goes w
 
 ![](/images/guide/run-example-soul/01-debugger-ui.png)
 
-This is what happened when you ran the `soul-engine dev` command:
+This is what happened when you ran `node ../../runtime/cli.js .`:
 
 ```mermaid
 flowchart LR
 
-yourComputer("Your computer \n\n (You ran soul-engine dev \n on Samantha's code)")
+yourComputer("Your computer \n\n (You ran the local runtime \n on Samantha's code)")
 soulEngine("Soul Engine servers \n\n (Samantha's soul runs here)")
 debugger("Debugger UI \n\n (The interface where you'll \n interact with Samantha)")
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -34,8 +34,8 @@ git clone https://github.com/opensouls/community
 cd community/souls/samantha-learns
 # and npm install
 npm install
-# and then run samantha
-npx soul-engine dev
+# and then run samantha using the local runtime
+node ../../runtime/cli.js .
 ```
 
 Those commands will open your web browser and you can chat with Samantha. Open up the samantha-learns directory in a code editor and try customizing the soul by modifying the `Samantha.md` file.

--- a/souls/alfred-learns-your-name/README.md
+++ b/souls/alfred-learns-your-name/README.md
@@ -8,5 +8,5 @@ He tries to learn your name, and once he does, instead of "interlocutor" saved i
 ## Run this soul
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/alfred-names/README.md
+++ b/souls/alfred-names/README.md
@@ -26,5 +26,5 @@ The `alfred-names` soul works by using a combination of foreground and backgroun
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/empty-soul/README.md
+++ b/souls/empty-soul/README.md
@@ -14,5 +14,5 @@ The minimum set of files in the `/soul` directory:
 ## Run this soul
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/env-vars/README.md
+++ b/souls/env-vars/README.md
@@ -9,5 +9,5 @@ This soul is purely utilitarian, just example code to show using environment var
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/example-twenty-questions/README.md
+++ b/souls/example-twenty-questions/README.md
@@ -36,5 +36,5 @@ The full definition can be found in the code, but this should provide a high-lev
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/hugo-guesses-rockstars/README.md
+++ b/souls/hugo-guesses-rockstars/README.md
@@ -19,5 +19,5 @@ The main files in the `/src` directory are:
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/multi-texting/README.md
+++ b/souls/multi-texting/README.md
@@ -9,5 +9,5 @@ This soul is designed to experiment with breaking up thoughts into chains of tex
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/poker-tutor/README.md
+++ b/souls/poker-tutor/README.md
@@ -27,5 +27,5 @@ When a poker game has been requested to start by the user, `playPoker` kicks off
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/raggy-knows-open-souls/README.md
+++ b/souls/raggy-knows-open-souls/README.md
@@ -23,5 +23,5 @@ npm run docs:push
 then
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/raggy-knows-open-souls/backgroundInformation/getting-started/connect-external-app.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/getting-started/connect-external-app.mdx
@@ -23,10 +23,10 @@ As a result you'll get a project folder that looks like this:
 
 ![](/images/guide/connect-external-app/01-init-soul.webp)
 
-Graham's blueprint doesn't exist in the Soul Engine yet, so let's run `soul-engine dev` to upload the code and also start the local development server:
+Graham's blueprint doesn't exist in the Soul Engine yet, so let's run the local runtime to upload the code and start the debugger:
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```
 
 If everything is working correctly, a new browser window should open with the Soul Engine debugger. You should also see confirmation that the code was uploaded in your terminal:
@@ -123,8 +123,9 @@ TELEGRAM_TOKEN="the token you received from BotFather"
 SOUL_ENGINE_BLUEPRINT="graham"
 SOUL_ENGINE_ORGANIZATION="add your Soul Engine organization id here"
 ```
+These `SOUL_ENGINE_*` variables are only needed when you connect to the hosted Soul Engine.
 
-Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `soul-engine dev`. You'll see a link there - your organization id is the first part of the path after `/chats`:
+Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `node ../../runtime/cli.js .`. You'll see a link there - your organization id is the first part of the path after `/chats`:
 
 ![](/images/guide/connect-external-app/08-url-parts.webp)
 
@@ -163,7 +164,7 @@ async function connectToSoulEngine(telegram: Telegraf<Context>) {
 // ...
 ```
 
-Find the terminal that's running your Telegram app (attention: this is not the one running `soul-engine dev`!). Stop the app by pressing `Ctrl+C` in the terminal, and then run it again with `npx tsx telegram/index.ts`. Now, when you send a message to the Graham, it should be his soul that replies:
+Find the terminal that's running your Telegram app (attention: this is not the one running `node ../../runtime/cli.js .`!). Stop the app by pressing `Ctrl+C` in the terminal, and then run it again with `npx tsx telegram/index.ts`. Now, when you send a message to the Graham, it should be his soul that replies:
 
 ![](/images/guide/connect-external-app/09-soul-connected.webp)
 

--- a/souls/raggy-knows-open-souls/backgroundInformation/getting-started/modify-example-soul.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/getting-started/modify-example-soul.mdx
@@ -6,12 +6,12 @@ As an introduction to the soul development process with the Soul Engine, we'll m
 
 ## Preparation
 
-Make sure the `soul-engine dev` process is running so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
+Make sure the local runtime (`node ../../runtime/cli.js .`) is running so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
 
 ```mermaid
 flowchart LR
 
-yourComputer("Your computer running \n soul-engine dev")
+yourComputer("Your computer running \n node ../../runtime/cli.js .")
 soulEngine("Soul Engine servers\n\n(Samantha is running here)")
 debugger("Debugger UI \n\n (The interface where you're \n interacting with Samantha)")
 
@@ -67,7 +67,7 @@ Now click the "Rewind" button that's right above your last message and try sayin
 
 ## Samantha doesn't need your computer to run
 
-Stop the execution of the `soul-engine dev` process by pressing `Ctrl + C` in the terminal:
+Stop the execution of the `node ../../runtime/cli.js .` process by pressing `Ctrl + C` in the terminal:
 
 ![](/images/guide/modify-example-soul/05-terminal.png)
 
@@ -75,6 +75,6 @@ Now try speaking to Samantha again. You'll see that she continues to answer in t
 
 ![](/images/guide/modify-example-soul/06-samantha-is-alive.png)
 
-Samantha's soul has been running on the Soul Engine servers since you ran `soul-engine dev` for the first time. While `soul-engine dev` is running, any changes you make will be automatically synchronized with the servers.
+Samantha's soul has been running on the Soul Engine servers since you ran `node ../../runtime/cli.js .` for the first time. While the process is running, any changes you make will be automatically synchronized with the servers.
 
 Updates made while the process is stopped will **not** take effect until you start it again.

--- a/souls/raggy-knows-open-souls/backgroundInformation/getting-started/run-example-soul.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/getting-started/run-example-soul.mdx
@@ -10,12 +10,12 @@ Follow the [quick start guide](/) to run the Samantha soul. If everything goes w
 
 ![](/images/guide/run-example-soul/01-debugger-ui.png)
 
-This is what happened when you ran the `soul-engine dev` command:
+This is what happened when you ran `node ../../runtime/cli.js .`:
 
 ```mermaid
 flowchart LR
 
-yourComputer("Your computer \n\n (You ran soul-engine dev \n on Samantha's code)")
+yourComputer("Your computer \n\n (You ran the local runtime \n on Samantha's code)")
 soulEngine("Soul Engine servers \n\n (Samantha's soul runs here)")
 debugger("Debugger UI \n\n (The interface where you'll \n interact with Samantha)")
 

--- a/souls/raggy-knows-open-souls/backgroundInformation/index.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/index.mdx
@@ -34,8 +34,8 @@ git clone https://github.com/opensouls/community
 cd community/souls/samantha-learns
 # and npm install
 npm install
-# and then run samantha
-npx soul-engine dev
+# and then run samantha using the local runtime
+node ../../runtime/cli.js .
 ```
 
 Those commands will open your web browser and you can chat with Samantha. Open up the samantha-learns directory in a code editor and try customizing the soul by modifying the `Samantha.md` file.

--- a/souls/samantha-learns/README.md
+++ b/souls/samantha-learns/README.md
@@ -27,5 +27,5 @@ The source code for these processes can be found in the `./soul` directory.
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/schedule-interact/README.md
+++ b/souls/schedule-interact/README.md
@@ -20,5 +20,5 @@ The source code for these processes can be found in the `./soul` directory.
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/schedule-tester/README.md
+++ b/souls/schedule-tester/README.md
@@ -14,5 +14,5 @@ The source code for these processes can be found in the `./src` directory.
 In this directory run
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/sinky-explains-opensouls/README.md
+++ b/souls/sinky-explains-opensouls/README.md
@@ -15,5 +15,5 @@ npx soul-engine rag push ./rag
 then
 
 ```bash
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```

--- a/souls/sinky-explains-opensouls/rag/soulengine/getting-started.mdx
+++ b/souls/sinky-explains-opensouls/rag/soulengine/getting-started.mdx
@@ -22,7 +22,7 @@ Finally, navigate to the root directory of your cloned soul and run
 
 ```bash
 cd samantha
-npx soul-engine dev
+node ../../runtime/cli.js .
 ```
 
 which will connect your soul to the engine and open the Soul Engine web interface.


### PR DESCRIPTION
## Summary
- replace `npx soul-engine dev` references across docs and READMEs
- clarify that `SOUL_ENGINE_*` env vars are only needed with the hosted engine
- update getting started guides to show `node ../../runtime/cli.js .`
- install missing dependencies so tests pass

## Testing
- `cd runtime && npm test`