### PR TITLE
Support TS entrypoints in runtime CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ soul.
 cd souls/example-twenty-questions
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources, so no prebuild step is needed.
 
 ## 💫 AI Souls
 
@@ -24,6 +25,7 @@ AI Souls are agentic and embodied digital beings, one day comprising thousands o
 1. Clone the repository and install dependencies for any soul you wish to run.
 1. Export your OpenAI API key: `export OPENAI_API_KEY=your-key`.
 1. Run the soul with `node ../../runtime/cli.js .`
+   (the CLI automatically transpiles TypeScript sources)
 
 Make sure to checkout the [documentation](https://docs.souls.chat)!
 

--- a/docs/pages/getting-started/connect-external-app.mdx
+++ b/docs/pages/getting-started/connect-external-app.mdx
@@ -28,6 +28,7 @@ Graham's blueprint doesn't exist in the Soul Engine yet, so let's run the local 
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.
 
 If everything is working correctly, a new browser window should open with the Soul Engine debugger. You should also see confirmation that the code was uploaded in your terminal:
 
@@ -125,7 +126,7 @@ SOUL_ENGINE_ORGANIZATION="add your Soul Engine organization id here"
 ```
 These `SOUL_ENGINE_*` variables are only needed when you connect to the hosted Soul Engine.
 
-Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `node ../../runtime/cli.js .`. You'll see a link there - your organization id is the first part of the path after `/chats`:
+Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `node ../../runtime/cli.js .`. (The CLI transpiles TypeScript automatically.) You'll see a link there - your organization id is the first part of the path after `/chats`:
 
 ![](/images/guide/connect-external-app/08-url-parts.webp)
 

--- a/docs/pages/getting-started/modify-example-soul.mdx
+++ b/docs/pages/getting-started/modify-example-soul.mdx
@@ -6,7 +6,7 @@ As an introduction to the soul development process with the Soul Engine, we'll m
 
 ## Preparation
 
-Make sure the local runtime (`node ../../runtime/cli.js .`) is running so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
+Make sure the local runtime (`node ../../runtime/cli.js .`) is running (it transpiles any TypeScript for you) so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
 
 ```mermaid
 flowchart LR
@@ -75,6 +75,6 @@ Now try speaking to Samantha again. You'll see that she continues to answer in t
 
 ![](/images/guide/modify-example-soul/06-samantha-is-alive.png)
 
-Samantha's soul has been running on the Soul Engine servers since you ran `node ../../runtime/cli.js .` for the first time. While the process is running, any changes you make will be automatically synchronized with the servers.
+Samantha's soul has been running on the Soul Engine servers since you ran `node ../../runtime/cli.js .` for the first time. While the process is running (and transpiling your TypeScript), any changes you make will be automatically synchronized with the servers.
 
 Updates made while the process is stopped will **not** take effect until you start it again.

--- a/docs/pages/getting-started/run-example-soul.mdx
+++ b/docs/pages/getting-started/run-example-soul.mdx
@@ -10,7 +10,7 @@ Follow the [quick start guide](/) to run the Samantha soul. If everything goes w
 
 ![](/images/guide/run-example-soul/01-debugger-ui.png)
 
-This is what happened when you ran `node ../../runtime/cli.js .`:
+This is what happened when you ran `node ../../runtime/cli.js .` (which automatically transpiles TypeScript sources):
 
 ```mermaid
 flowchart LR

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -37,6 +37,7 @@ npm install
 # and then run samantha using the local runtime
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.
 
 Those commands will open your web browser and you can chat with Samantha. Open up the samantha-learns directory in a code editor and try customizing the soul by modifying the `Samantha.md` file.
 

--- a/runtime/cli.js
+++ b/runtime/cli.js
@@ -1,13 +1,65 @@
 import path from 'path';
 import readline from 'readline';
-import { createRuntime, loadEnvironment, loadBlueprint, loadSubprocesses } from './index.js';
-import { fileURLToPath } from 'url';
+import fs from 'fs/promises';
+import os from 'os';
+import * as ts from 'typescript';
+import { createRuntime, loadEnvironment, loadBlueprint } from './index.js';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-async function loadProcess(soulDir) {
-  const procPath = path.resolve(soulDir, 'soul', 'initialProcess.js');
-  return (await import(procPath)).default;
+async function exists(p) {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+
+async function compileTs(file) {
+  const source = await fs.readFile(file, 'utf8');
+  const runtimeUrl = pathToFileURL(path.resolve(__dirname, 'index.js')).href;
+  const replaced = source.replace('@opensouls/local-engine', runtimeUrl);
+  const jsSource = ts.transpileModule(replaced, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 }
+  }).outputText;
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'soul-'));
+  const jsPath = path.join(tmpDir, path.basename(file, '.ts') + '.js');
+  await fs.writeFile(jsPath, jsSource);
+  return jsPath;
+}
+
+export async function loadProcess(soulDir) {
+  const jsPath = path.resolve(soulDir, 'soul', 'initialProcess.js');
+  const tsPath = path.resolve(soulDir, 'soul', 'initialProcess.ts');
+  let modPath;
+  if (await exists(jsPath)) {
+    modPath = jsPath;
+  } else if (await exists(tsPath)) {
+    modPath = await compileTs(tsPath);
+  } else {
+    throw new Error('initialProcess.ts or initialProcess.js not found');
+  }
+  return (await import(pathToFileURL(modPath).href)).default;
+}
+
+export async function loadSubprocesses(soulDir) {
+  const dir = path.resolve(soulDir, 'soul', 'subprocesses');
+  try {
+    const stat = await fs.stat(dir);
+    if (!stat.isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  const files = (await fs.readdir(dir))
+    .filter(f => f.endsWith('.js') || f.endsWith('.ts'))
+    .sort();
+  const procs = [];
+  for (const file of files) {
+    let filePath = path.join(dir, file);
+    if (file.endsWith('.ts')) {
+      filePath = await compileTs(filePath);
+    }
+    const mod = await import(pathToFileURL(filePath).href);
+    procs.push(mod.default);
+  }
+  return procs;
 }
 
 async function main() {
@@ -41,4 +93,6 @@ async function main() {
   });
 }
 
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/runtime/test/env-vars.test.js
+++ b/runtime/test/env-vars.test.js
@@ -1,11 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs/promises';
-import os from 'os';
 import path from 'path';
-import { pathToFileURL } from 'url';
-import * as ts from 'typescript';
 import { createRuntime, loadEnvironment, loadBlueprint, ChatMessageRoleEnum, $$ } from '../index.js';
+import { loadProcess } from '../cli.js';
 
 const soulDir = path.resolve('../souls/env-vars');
 
@@ -21,25 +19,10 @@ test('blueprint markdown is expanded using env vars', async () => {
   assert.equal(loaded, expected);
 });
 
-async function compileProcess() {
-  const tsPath = path.resolve('../souls/env-vars/soul/initialProcess.ts');
-  const tsSource = await fs.readFile(tsPath, 'utf8');
-  const runtimeUrl = pathToFileURL(path.resolve('index.js')).href;
-  const replaced = tsSource.replace('@opensouls/local-engine', runtimeUrl);
-  const jsSource = ts.transpileModule(replaced, {
-    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 }
-  }).outputText;
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'env-'));
-  const jsPath = path.join(tmpDir, 'initialProcess.js');
-  await fs.writeFile(jsPath, jsSource);
-  return pathToFileURL(jsPath).href;
-}
-
 test('environment variables are loaded and templated', async () => {
   const env = await loadEnvironment(soulDir);
   const blueprint = await loadBlueprint(soulDir, env);
-  const procUrl = await compileProcess();
-  const { default: initialProcess } = await import(procUrl);
+  const initialProcess = await loadProcess(soulDir);
   const runtime = createRuntime({ initialProcess, soulName: 'Env', env, blueprint });
 
   assert.equal(runtime.workingMemory.memories.length, 1);

--- a/souls/alfred-learns-your-name/README.md
+++ b/souls/alfred-learns-your-name/README.md
@@ -10,3 +10,4 @@ He tries to learn your name, and once he does, instead of "interlocutor" saved i
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/alfred-names/README.md
+++ b/souls/alfred-names/README.md
@@ -28,3 +28,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/empty-soul/README.md
+++ b/souls/empty-soul/README.md
@@ -16,3 +16,4 @@ The minimum set of files in the `/soul` directory:
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/env-vars/README.md
+++ b/souls/env-vars/README.md
@@ -11,3 +11,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/example-twenty-questions/README.md
+++ b/souls/example-twenty-questions/README.md
@@ -38,3 +38,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/hugo-guesses-rockstars/README.md
+++ b/souls/hugo-guesses-rockstars/README.md
@@ -21,3 +21,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/multi-texting/README.md
+++ b/souls/multi-texting/README.md
@@ -11,3 +11,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/poker-tutor/README.md
+++ b/souls/poker-tutor/README.md
@@ -29,3 +29,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/raggy-knows-open-souls/README.md
+++ b/souls/raggy-knows-open-souls/README.md
@@ -25,3 +25,4 @@ then
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/raggy-knows-open-souls/backgroundInformation/getting-started/connect-external-app.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/getting-started/connect-external-app.mdx
@@ -28,6 +28,7 @@ Graham's blueprint doesn't exist in the Soul Engine yet, so let's run the local 
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.
 
 If everything is working correctly, a new browser window should open with the Soul Engine debugger. You should also see confirmation that the code was uploaded in your terminal:
 
@@ -125,7 +126,7 @@ SOUL_ENGINE_ORGANIZATION="add your Soul Engine organization id here"
 ```
 These `SOUL_ENGINE_*` variables are only needed when you connect to the hosted Soul Engine.
 
-Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `node ../../runtime/cli.js .`. You'll see a link there - your organization id is the first part of the path after `/chats`:
+Not sure what's your Soul Engine organization id? Take a look at the terminal output when you run `node ../../runtime/cli.js .`. (The CLI transpiles TypeScript automatically.) You'll see a link there - your organization id is the first part of the path after `/chats`:
 
 ![](/images/guide/connect-external-app/08-url-parts.webp)
 

--- a/souls/raggy-knows-open-souls/backgroundInformation/getting-started/modify-example-soul.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/getting-started/modify-example-soul.mdx
@@ -6,7 +6,7 @@ As an introduction to the soul development process with the Soul Engine, we'll m
 
 ## Preparation
 
-Make sure the local runtime (`node ../../runtime/cli.js .`) is running so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
+Make sure the local runtime (`node ../../runtime/cli.js .`) is running (it will transpile any TypeScript you edit) so the changes you make take effect. Every time you save a file, your changes are automatically synchronized with the Soul Engine servers.
 
 ```mermaid
 flowchart LR
@@ -75,6 +75,6 @@ Now try speaking to Samantha again. You'll see that she continues to answer in t
 
 ![](/images/guide/modify-example-soul/06-samantha-is-alive.png)
 
-Samantha's soul has been running on the Soul Engine servers since you ran `node ../../runtime/cli.js .` for the first time. While the process is running, any changes you make will be automatically synchronized with the servers.
+Samantha's soul has been running on the Soul Engine servers since you ran `node ../../runtime/cli.js .` for the first time. While the process is running (and transpiling your TypeScript), any changes you make will be automatically synchronized with the servers.
 
 Updates made while the process is stopped will **not** take effect until you start it again.

--- a/souls/raggy-knows-open-souls/backgroundInformation/getting-started/run-example-soul.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/getting-started/run-example-soul.mdx
@@ -10,7 +10,7 @@ Follow the [quick start guide](/) to run the Samantha soul. If everything goes w
 
 ![](/images/guide/run-example-soul/01-debugger-ui.png)
 
-This is what happened when you ran `node ../../runtime/cli.js .`:
+This is what happened when you ran `node ../../runtime/cli.js .` (which automatically transpiles TypeScript sources):
 
 ```mermaid
 flowchart LR

--- a/souls/raggy-knows-open-souls/backgroundInformation/index.mdx
+++ b/souls/raggy-knows-open-souls/backgroundInformation/index.mdx
@@ -37,6 +37,7 @@ npm install
 # and then run samantha using the local runtime
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.
 
 Those commands will open your web browser and you can chat with Samantha. Open up the samantha-learns directory in a code editor and try customizing the soul by modifying the `Samantha.md` file.
 

--- a/souls/samantha-learns/README.md
+++ b/souls/samantha-learns/README.md
@@ -29,3 +29,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/schedule-interact/README.md
+++ b/souls/schedule-interact/README.md
@@ -22,3 +22,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/schedule-tester/README.md
+++ b/souls/schedule-tester/README.md
@@ -16,3 +16,4 @@ In this directory run
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/sinky-explains-opensouls/README.md
+++ b/souls/sinky-explains-opensouls/README.md
@@ -17,3 +17,4 @@ then
 ```bash
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.

--- a/souls/sinky-explains-opensouls/rag/soulengine/getting-started.mdx
+++ b/souls/sinky-explains-opensouls/rag/soulengine/getting-started.mdx
@@ -24,6 +24,7 @@ Finally, navigate to the root directory of your cloned soul and run
 cd samantha
 node ../../runtime/cli.js .
 ```
+The CLI automatically transpiles TypeScript sources.
 
 which will connect your soul to the engine and open the Soul Engine web interface.
 


### PR DESCRIPTION
## Summary
- transpile `.ts` files in `runtime/cli.js`
- note automatic TypeScript handling in docs and examples
- update tests to use the new transpiler

## Testing
- `cd runtime && npm test`