### PR TITLE
Add initial documentation scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,20 @@
-# 🤖+👱 OPEN SOULS (Community)
+# 🤖🕯 **OPEN SOULS (Community Runtime)**
+Local daemon engine for building *process-only* AI Souls.
+No “self,” no centralized mind—just perceptions in, actions out.
 
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/OpenSoulsPBC.svg?style=social&label=Follow%20%40OpenSoulsPBC)](https://twitter.com/OpenSoulsPBC) [![](https://dcbadge.vercel.app/api/server/FCPcCUbw3p?compact=true&style=flat)](https://discord.gg/opensouls)
-
-## 🤔 What is this?
-
-This repository is a place for sharing knowledge on how to create AI souls. This repository holds docs, snippets, and examples for building AI souls with `@opensouls/core` and our **local runtime**. The runtime is published as `@opensouls/local-engine`.
-
-
-Any soul in the repo can be run locally using the new runtime. The runtime uses
-the OpenAI API, so set `OPENAI_API_KEY` in your environment before running a
-soul.
+## Quick-start
 
 ```bash
-cd souls/example-twenty-questions
-node ../../runtime/cli.js .
+git clone https://github.com/brianmulder/open-souls-community.git
+cd open-souls-community
+npm install          # installs Node + CLI
+npm run soul dev ./souls/example-twenty-questions   # spawn a soul
 ```
-The CLI automatically transpiles TypeScript sources, so no prebuild step is needed.
 
-## 💫 AI Souls
+## Docs
 
-AI Souls are agentic and embodied digital beings, one day comprising thousands of mental processes managed by the runtime. Unlike traditional chatbots, this code will give digital souls personality, drive, ego, and will.
+* [VISION](./VISION.md) – philosophical spine
+* [ROADMAP](./ROADMAP.md) – where we’re going
+* [docs/](./docs/) – deep dives (architecture, plugins, UI)
 
-## 🔑 Getting Started
-1. Clone the repository and install dependencies for any soul you wish to run.
-1. Export your OpenAI API key: `export OPENAI_API_KEY=your-key`.
-1. Run the soul with `node ../../runtime/cli.js .`
-   (the CLI automatically transpiles TypeScript sources)
-
-Make sure to checkout the [documentation](https://docs.souls.chat)!
-
-## 🙋 Contributing
-
-Check out [CONTRIBUTING](./CONTRIBUTING.md) and open up a PR!
-
-We're excited for contributions, such as:
-  - Reporting bugs
-  - Suggesting enhancements
-  - Submitting new example souls
-  - Contributing cognitive steps and other code to the library
-  - Improving documentation
-  - Providing feedback
-
-## 📜 License
-
-The documentation (`/docs`) is included under CC-BY-4.0 license.
-
-Unless otherise noted, the remainder of the repository - i.e. the `/library`, `/demos`, and `/souls` are included under MIT license.
+---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,13 @@
+# rolling four-beat plan – update each cycle
+
+| Phase | Target slice                                              | ETA        | Status    |
+| ----- | --------------------------------------------------------- | ---------- | --------- |
+| 0     | Perception/Action schema, refactor `dispatch` → `ingest`  | 2025-05-30 | 🔄 in-dev |
+| 1     | Memory + reflection loop, vector recall                   | 2025-06-15 | ⏳         |
+| 2     | Supervisor (multi-daemon, IPC, restart)                   | 2025-06-30 | ⏳         |
+| 3     | Perception-Feed UI (basic) + character-card import/export | 2025-07-15 | ⏳         |
+| 4     | Plugin SDK + sample clock/filewatch                       | Q3 2025    | ⏳         |
+
+Historic milestones live in `docs/archive/original-runtime-plan-2025-04.md`.
+
+---

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,11 @@
+# Post-Cartesian Manifesto
+
+1. **Ontology** – Everything is `Perception` → *MentalProcess* → `Action`.
+2. **Continuity** – Souls are *daemons* that live locally, dream in silence, speak only when compelled.
+3. **Privacy** – All state & memory remain on the user’s box. Zero cloud leakage unless explicitly allowed.
+4. **Extensibility** – Clock ticks, game sensors, tool calls—everything is a plugin.
+5. **Accessibility** – character card ui for non-coders; API for hackers.
+
+> *“No self, only becoming.”* – Deleuzian footnote
+
+---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+## Big-picture
+
+```mermaid
+graph TD
+    A[Perception sources] -->|emit| R(Runtime Daemon)
+    R -->|invoke| MP[MentalProcess]
+    MP -->|produce| AC(Action)
+    AC -->|route| SUP(Supervisor)
+    SUP -->|display| UI(Perception Feed UI)
+    SUP -->|deliver| EXT(Environment / Plugins)
+```
+
+* **Runtime Daemon** – single-agent event loop (one OS process per soul).
+* **Supervisor** – spawns daemons, routes events, restarts on crash.
+* **UI** – simple timeline; input box just emits `Perception{type:"utterance"}`.
+* **Plugins** – bidirectional adapters (clock, game engine, etc.).
+
+---

--- a/docs/archive/original-runtime-plan-2025-04.md
+++ b/docs/archive/original-runtime-plan-2025-04.md
@@ -1,0 +1,3 @@
+# Original Runtime Plan (April 2025)
+
+*Historical reference only.*

--- a/docs/archive/runtime-implementation-plan-2025-05-18.md
+++ b/docs/archive/runtime-implementation-plan-2025-05-18.md
@@ -1,3 +1,5 @@
+> **Historical reference only – replaced by `roadmap-implementation-plan.md`**
+
 # Runtime Implementation Plan
 
 This document outlines the steps required to add missing functionality to the local runtime. The milestones are based on the gaps identified in the documentation and example souls under `souls/`.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,10 @@
+### Layers
+
+1. **Working memory** – last N perceptions kept in RAM.
+2. **Episodic log** – append-only JSONL, each line `{ts, text, vec}`.
+3. **Vector index** – FAISS / Chroma sidecar per soul (`.store/vec/`).
+4. **Reflections** – scheduled summary process promotes insights to `beliefs[]`.
+
+**Embedding pipeline**: OpenAI API (default) or local `all-MiniLM`. Config via env `EMBED_BACKEND`.
+
+---

--- a/docs/perceptions-actions.md
+++ b/docs/perceptions-actions.md
@@ -1,0 +1,28 @@
+## Canonical event schema (v0.1)
+
+```ts
+interface Perception {
+  type: string          // e.g. "utterance", "vision", "tick"
+  payload: unknown      // arbitrary JSON
+  ts: number            // epoch-ms
+}
+
+interface Action {
+  type: string          // e.g. "utterance", "move", "http"
+  payload: unknown
+  ts: number
+}
+```
+
+### Core `type` values
+
+| Domain          | Perception                   | Action                       |
+| --------------- | ---------------------------- | ---------------------------- |
+| Conversational  | `utterance` `{speaker,text}` | `utterance` `{speaker,text}` |
+| Time            | `tick` `{secs}`              | —                            |
+| Movement (ext.) | `location` `{x,y}`           | `move` `{to}`                |
+| Custom plugins  | arbitrary                    | arbitrary                    |
+
+> **Rule:** runtime never interprets *who* the speaker “is”; that’s context stored in `payload`.
+
+---

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -1,0 +1,16 @@
+### Writing a plugin
+
+```ts
+export const id = 'clock'
+
+export function init({ publishPerception }) {
+  setInterval(() => {
+    publishPerception({ type: 'tick', payload: { secs: 60 }, ts: Date.now() })
+  }, 60000)
+}
+```
+
+* Drop file in `/plugins`; supervisor auto-loads.
+* Plugins can also **consume actions** by exporting `onAction(action)`.
+
+---

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1,0 +1,15 @@
+### Public helpers exposed to MentalProcess code
+
+```ts
+runtime.perceive(p: Perception): void              // ingest new perception
+runtime.act(a: Action): void                       // enqueue outbound action
+runtime.wait(ms: number): Promise<void>            // scheduler sleep
+runtime.store.get(key): any                        // KV persistence
+runtime.store.set(key, val): void
+runtime.memory.append(text, importance?): void     // episodic log
+runtime.memory.search(query, k?): MemoryItem[]     // vector recall
+```
+
+All helpers are Promise-friendly and test-covered (see `runtime/test/`).
+
+---

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,10 @@
+### Event queue
+
+* Min-heap keyed by `scheduledTs`.
+* `scheduleEvent(fn, delayMs)` → returns `id`.
+* `cancelEvent(id)` → clears.
+* Supports `pause`, `resume`.
+
+Edge-cases covered in `scheduler.test.ts`: clock skew, long sleep, concurrent inserts.
+
+---

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -1,0 +1,10 @@
+* Node master that:
+
+  * reads `souls.config.json`
+  * spawns each soul via `child_process.fork`
+  * routes JSON-RPC messages (`perception`, `action`, `heartbeat`)
+  * restarts crashed souls (exponential back-off)
+
+IPC default = Unix socket `~/opensouls.sock`; Windows uses named pipe.
+
+---

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,12 @@
+### Perception Feed UX
+
+| Element             | Function                                                  |
+| ------------------- | --------------------------------------------------------- |
+| Timeline            | Renders ordered perceptions/actions with icon per `type`. |
+| Input bar           | Emits `Perception{type:"utterance", speaker:"human"}`.    |
+| Memory drawer (dev) | Shows last 10 memories + current mood/state.              |
+| Soul switcher       | Toggles which souls are subscribed to this room.          |
+
+Built with **Next.js + Tailwind**; hot-reload with `npm run dev:ui`.
+
+---


### PR DESCRIPTION
## Summary
- replace README with brief quick-start billboard
- add manifesto to `VISION.md`
- outline phases in `ROADMAP.md`
- document architecture, APIs, memory and more under `docs/`
- archive old runtime plan with a historic banner

## Testing
- `cd runtime && npm test`