### PR TITLE
Implement perception core API

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -1,7 +1,7 @@
 ### Public helpers exposed to MentalProcess code
 
 ```ts
-runtime.perceive(p: Perception): void              // ingest new perception
+runtime.ingestPerception(p: Perception): void     // ingest new perception
 runtime.act(a: Action): void                       // enqueue outbound action
 runtime.wait(ms: number): Promise<void>            // scheduler sleep
 runtime.store.get(key): any                        // KV persistence

--- a/roadmap-implementation-plan.md
+++ b/roadmap-implementation-plan.md
@@ -16,7 +16,7 @@ Every feature must ship with:
 
 ---
 
-## Milestone 0 · Docs Bootstrap  
+## Milestone 0 · Docs Bootstrap ✅
 Create the fresh documentation scaffold (see <scaffold> below) already agreed on (`README.md`, `VISION.md`, `ROADMAP.md`, `docs/*`).   
 Move the obsolete `runtime-implementation-plan.md` into `docs/archive/` with a “historical reference only” banner.  
 **Acceptance:** `npm test` green, repo root shows new files, README links to docs.

--- a/runtime/cli.js
+++ b/runtime/cli.js
@@ -3,7 +3,7 @@ import readline from 'readline';
 import fs from 'fs/promises';
 import os from 'os';
 import * as ts from 'typescript';
-import { createRuntime, loadEnvironment, loadBlueprint } from './index.js';
+import { createRuntime, loadEnvironment, loadBlueprint, createPerception } from './index.js';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -80,15 +80,19 @@ async function main() {
     blueprint,
     storeDir: path.join(soulDir, '.store')
   });
-  runtime.on('says', ({ content }) => {
-    console.log(path.basename(soulDir), 'says:', content);
+  runtime.on('act', action => {
+    if (action.type === 'utterance') {
+      console.log(path.basename(soulDir), 'says:', action.payload);
+    } else {
+      console.log(path.basename(soulDir), 'action:', JSON.stringify(action));
+    }
   });
   runtime.on('log', (...args) => console.log('[log]', ...args));
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   rl.setPrompt('> ');
   rl.prompt();
   rl.on('line', async line => {
-    await runtime.dispatch({ action: 'said', name: 'User', content: line });
+    await runtime.ingestPerception(createPerception('utterance', line));
     rl.prompt();
   });
 }

--- a/runtime/test/env-vars.test.js
+++ b/runtime/test/env-vars.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs/promises';
 import path from 'path';
-import { createRuntime, loadEnvironment, loadBlueprint, ChatMessageRoleEnum, $$ } from '../index.js';
+import { createRuntime, loadEnvironment, loadBlueprint, ChatMessageRoleEnum, $$, createPerception } from '../index.js';
 import { loadProcess } from '../cli.js';
 
 const soulDir = path.resolve('../souls/env-vars');
@@ -29,12 +29,12 @@ test('environment variables are loaded and templated', async () => {
   const [systemBefore] = runtime.workingMemory.memories;
   assert.equal(systemBefore.content, blueprint);
 
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
 
-  await runtime.dispatch({ action: 'said', name: 'User', content: 'hi' });
+  await runtime.ingestPerception(createPerception('utterance', 'hi'));
 
-  assert.deepEqual(says, ['I like alice, pumpkins.']);
+  assert.deepEqual(acts, ['I like alice, pumpkins.']);
   assert.equal(runtime.workingMemory.memories.length, 2);
   const [system, user] = runtime.workingMemory.memories;
   assert.equal(system.role, ChatMessageRoleEnum.System);

--- a/runtime/test/host-empty-soul.test.js
+++ b/runtime/test/host-empty-soul.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
-import { createRuntime, ChatMessageRoleEnum } from '../index.js';
+import { createRuntime, ChatMessageRoleEnum, createPerception } from '../index.js';
 import { loadProcess } from '../cli.js';
 
 test('runtime hosts the empty soul', async () => {
@@ -19,13 +19,13 @@ test('runtime hosts the empty soul', async () => {
   const soulDir = path.resolve('../souls/empty-soul');
   const initialProcess = await loadProcess(soulDir);
   const runtime = createRuntime({ initialProcess, soulName: 'Golem' });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
 
-  await runtime.dispatch({ action: 'said', name: 'User', content: 'hi' });
+  await runtime.ingestPerception(createPerception('utterance', 'hi'));
 
   assert.ok(fetchCalled, 'OpenAI API should be called');
-  assert.deepEqual(says, ['Hello world']);
+  assert.deepEqual(acts, ['Hello world']);
   assert.equal(runtime.workingMemory.memories.length, 2);
   const [user, assistant] = runtime.workingMemory.memories;
   assert.equal(user.role, ChatMessageRoleEnum.User);

--- a/runtime/test/perceptions.test.js
+++ b/runtime/test/perceptions.test.js
@@ -1,25 +1,25 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createRuntime, useActions, useProcessManager, usePerceptions } from '../index.js';
+import { createRuntime, useActions, useProcessManager, usePerceptions, createPerception } from '../index.js';
 
 const checkProcess = async ({ workingMemory }) => {
-  const { speak } = useActions();
+  const { act } = useActions();
   const { wait } = useProcessManager();
   const { invokingPerception, pendingPerceptions } = usePerceptions();
   await wait(30);
-  speak(`${invokingPerception.action}:${pendingPerceptions.current.length}`);
+  act({ type: 'utterance', payload: `${invokingPerception.type}:${pendingPerceptions.current.length}`, ts: Date.now() });
   return workingMemory;
 };
 
 test('invokingPerception and pendingPerceptions are tracked', async () => {
   const runtime = createRuntime({ initialProcess: checkProcess, soulName: 'Test' });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
 
-  const first = runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
-  setTimeout(() => runtime.dispatch({ action: 'poke', name: 'User', content: 'yo' }), 10);
+  const first = runtime.ingestPerception(createPerception('start', 'hi'));
+  setTimeout(() => runtime.ingestPerception(createPerception('poke', 'yo')), 10);
   await first;
   await new Promise(res => setTimeout(res, 50));
 
-  assert.deepEqual(says, ['start:1', 'poke:0']);
+  assert.deepEqual(acts, ['start:1', 'poke:0']);
 });

--- a/runtime/test/process-manager.test.js
+++ b/runtime/test/process-manager.test.js
@@ -1,18 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createRuntime, useActions, useProcessManager } from '../index.js';
+import { createRuntime, useActions, useProcessManager, createPerception } from '../index.js';
 
 const processB = async ({ workingMemory }) => {
   const { previousMentalProcess, invocationCount } = useProcessManager();
-  const { speak } = useActions();
-  speak(`B ${invocationCount} prev:${previousMentalProcess === processA}`);
+  const { act } = useActions();
+  act({ type: 'utterance', payload: `B ${invocationCount} prev:${previousMentalProcess === processA}`, ts: Date.now() });
   return workingMemory;
 };
 
 const processA = async ({ workingMemory }) => {
   const { invocationCount, setNextProcess } = useProcessManager();
-  const { speak } = useActions();
-  speak(`A ${invocationCount}`);
+  const { act } = useActions();
+  act({ type: 'utterance', payload: `A ${invocationCount}`, ts: Date.now() });
   if (invocationCount === 0) {
     setNextProcess(processB);
   }
@@ -21,25 +21,25 @@ const processA = async ({ workingMemory }) => {
 
 test('previousMentalProcess and invocationCount are tracked', async () => {
   const runtime = createRuntime({ initialProcess: processA, soulName: 'Test' });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
 
   assert.equal(runtime.previousProcess, undefined);
 
-  await runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  await runtime.ingestPerception(createPerception('start', 'hi'));
   assert.equal(runtime.previousProcess, processA);
   assert.equal(runtime.currentProcess, processB);
   assert.equal(runtime.invocationCount, 0);
 
-  await runtime.dispatch({ action: 'cont', name: 'User', content: 'again' });
+  await runtime.ingestPerception(createPerception('cont', 'again'));
   assert.equal(runtime.previousProcess, processA);
   assert.equal(runtime.currentProcess, processB);
   assert.equal(runtime.invocationCount, 1);
 
-  await runtime.dispatch({ action: 'cont', name: 'User', content: 'again' });
+  await runtime.ingestPerception(createPerception('cont', 'again'));
   assert.equal(runtime.previousProcess, processA);
   assert.equal(runtime.currentProcess, processB);
   assert.equal(runtime.invocationCount, 2);
 
-  assert.deepEqual(says, ['A 0', 'B 0 prev:true', 'B 1 prev:true']);
+  assert.deepEqual(acts, ['A 0', 'B 0 prev:true', 'B 1 prev:true']);
 });

--- a/runtime/test/schedule-events.test.js
+++ b/runtime/test/schedule-events.test.js
@@ -1,44 +1,44 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createRuntime, useActions } from '../index.js';
+import { createRuntime, useActions, createPerception } from '../index.js';
 
 const handlePoke = async ({ workingMemory }) => {
-  const { speak } = useActions();
-  speak('poke event');
+  const { act } = useActions();
+  act({ type: 'utterance', payload: 'poke event', ts: Date.now() });
   return workingMemory;
 };
 
 let scheduledId;
 const scheduler = async ({ workingMemory }) => {
   const { scheduleEvent } = useActions();
-  scheduledId = scheduleEvent({ in: 0.05, perception: { action: 'poke', content: 'poke', name: 'Test' }, process: handlePoke });
+  scheduledId = scheduleEvent({ in: 0.05, perception: createPerception('poke', 'poke'), process: handlePoke });
   return workingMemory;
 };
 
 test('scheduled event executes after delay', async () => {
   const runtime = createRuntime({ initialProcess: scheduler, soulName: 'Test' });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
 
-  await runtime.dispatch({ action: 'start', content: 'go', name: 'Tester' });
+  await runtime.ingestPerception(createPerception('start', 'go'));
   assert.equal(runtime.getPendingEvents().length, 1);
 
   await new Promise(res => setTimeout(res, 80));
 
   assert.equal(runtime.getPendingEvents().length, 0);
-  assert.deepEqual(says, ['poke event']);
+  assert.deepEqual(acts, ['poke event']);
 });
 
 test('scheduled event can be cancelled', async () => {
   const runtime = createRuntime({ initialProcess: scheduler, soulName: 'Test' });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
 
-  await runtime.dispatch({ action: 'start', content: 'go', name: 'Tester' });
+  await runtime.ingestPerception(createPerception('start', 'go'));
   runtime.cancelScheduledEvent(scheduledId);
   assert.equal(runtime.getPendingEvents().length, 0);
 
   await new Promise(res => setTimeout(res, 80));
 
-  assert.deepEqual(says, []);
+  assert.deepEqual(acts, []);
 });

--- a/runtime/test/soul-memory.test.js
+++ b/runtime/test/soul-memory.test.js
@@ -1,20 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createRuntime, useActions, useSoulMemory } from '../index.js';
+import { createRuntime, useActions, useSoulMemory, createPerception } from '../index.js';
 
 const proc = async ({ workingMemory }) => {
-  const { speak } = useActions();
+  const { act } = useActions();
   const mem = useSoulMemory('flag', false);
-  speak(String(mem.current));
+  act({ type: 'utterance', payload: String(mem.current), ts: Date.now() });
   mem.current = true;
   return workingMemory;
 };
 
 test('useSoulMemory persists across invocations', async () => {
   const runtime = createRuntime({ initialProcess: proc, soulName: 'MemTest' });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
-  await runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
-  await runtime.dispatch({ action: 'again', name: 'User', content: 'hi' });
-  assert.deepEqual(says, ['false', 'true']);
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
+  await runtime.ingestPerception(createPerception('start', 'hi'));
+  await runtime.ingestPerception(createPerception('again', 'hi'));
+  assert.deepEqual(acts, ['false', 'true']);
 });

--- a/runtime/test/soul-store.test.js
+++ b/runtime/test/soul-store.test.js
@@ -3,30 +3,30 @@ import assert from 'node:assert/strict';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { createRuntime, useActions, useSoulStore } from '../index.js';
+import { createRuntime, useActions, useSoulStore, createPerception } from '../index.js';
 
 const proc = async ({ workingMemory }) => {
-  const { speak } = useActions();
+  const { act } = useActions();
   const store = useSoulStore();
   const count = (await store.fetch('count')) || 0;
   await store.set('count', count + 1);
   const updated = await store.fetch('count');
-  speak(String(updated));
+  act({ type: 'utterance', payload: String(updated), ts: Date.now() });
   return workingMemory;
 };
 
 test('useSoulStore persists to disk', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'store-'));
   const runtime1 = createRuntime({ initialProcess: proc, soulName: 'Store', storeDir: dir });
-  const says1 = [];
-  runtime1.on('says', ({ content }) => says1.push(content));
-  await runtime1.dispatch({ action: 'start', name: 'User', content: 'hi' });
-  assert.deepEqual(says1, ['1']);
+  const acts1 = [];
+  runtime1.on('act', a => acts1.push(a.payload));
+  await runtime1.ingestPerception(createPerception('start', 'hi'));
+  assert.deepEqual(acts1, ['1']);
 
   const runtime2 = createRuntime({ initialProcess: proc, soulName: 'Store', storeDir: dir });
-  const says2 = [];
-  runtime2.on('says', ({ content }) => says2.push(content));
-  await runtime2.dispatch({ action: 'start', name: 'User', content: 'hi' });
-  assert.deepEqual(says2, ['2']);
+  const acts2 = [];
+  runtime2.on('act', a => acts2.push(a.payload));
+  await runtime2.ingestPerception(createPerception('start', 'hi'));
+  assert.deepEqual(acts2, ['2']);
 });
 

--- a/runtime/test/subprocesses.test.js
+++ b/runtime/test/subprocesses.test.js
@@ -1,49 +1,49 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createRuntime, useActions, useProcessManager } from '../index.js';
+import { createRuntime, useActions, useProcessManager, createPerception } from '../index.js';
 
 const main = async ({ workingMemory }) => {
-  const { speak } = useActions();
-  speak('main');
+  const { act } = useActions();
+  act({ type: 'utterance', payload: 'main', ts: Date.now() });
   return workingMemory;
 };
 
 const sub1 = async ({ workingMemory }) => {
-  const { speak } = useActions();
-  speak('sub1');
+  const { act } = useActions();
+  act({ type: 'utterance', payload: 'sub1', ts: Date.now() });
   return workingMemory;
 };
 
 test('subprocess runs after process', async () => {
   const runtime = createRuntime({ initialProcess: main, soulName: 'Sub', subprocesses: [sub1] });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
-  await runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
+  await runtime.ingestPerception(createPerception('start', 'hi'));
   await new Promise(res => setTimeout(res, 10));
-  assert.deepEqual(says, ['main', 'sub1']);
+  assert.deepEqual(acts, ['main', 'sub1']);
 });
 
 const waitSub = async ({ workingMemory }) => {
-  const { speak } = useActions();
+  const { act } = useActions();
   const { wait } = useProcessManager();
   await wait(20);
-  speak('waited');
+  act({ type: 'utterance', payload: 'waited', ts: Date.now() });
   return workingMemory;
 };
 
 const sub2 = async ({ workingMemory }) => {
-  const { speak } = useActions();
-  speak('sub2');
+  const { act } = useActions();
+  act({ type: 'utterance', payload: 'sub2', ts: Date.now() });
   return workingMemory;
 };
 
 test('subprocess chain stops on new perception', async () => {
   const runtime = createRuntime({ initialProcess: main, soulName: 'Sub', subprocesses: [waitSub, sub2] });
-  const says = [];
-  runtime.on('says', ({ content }) => says.push(content));
-  const first = runtime.dispatch({ action: 'start', name: 'User', content: 'hi' });
-  setTimeout(() => runtime.dispatch({ action: 'next', name: 'User', content: 'yo' }), 10);
+  const acts = [];
+  runtime.on('act', a => acts.push(a.payload));
+  const first = runtime.ingestPerception(createPerception('start', 'hi'));
+  setTimeout(() => runtime.ingestPerception(createPerception('next', 'yo')), 10);
   await first;
   await new Promise(res => setTimeout(res, 50));
-  assert.deepEqual(says, ['main', 'waited', 'main', 'waited', 'sub2']);
+  assert.deepEqual(acts, ['main', 'waited', 'main', 'waited', 'sub2']);
 });

--- a/souls/empty-soul/soul/initialProcess.ts
+++ b/souls/empty-soul/soul/initialProcess.ts
@@ -1,12 +1,12 @@
 
-import { MentalProcess, createCognitiveStep, useActions } from "@opensouls/local-engine";
+import { MentalProcess, createCognitiveStep, useActions, createAction } from "@opensouls/local-engine";
 
 const golem: MentalProcess = async ({ workingMemory }) => {
-  const { speak } = useActions()
+  const { act } = useActions()
   const [withDialog, text] = await createCognitiveStep((instruction: string) => {
     return { command: instruction }
   })(workingMemory,"");
-  speak(text);
+  act(createAction('utterance', text));
   return withDialog;
 }
 


### PR DESCRIPTION
## Summary
- mark docs bootstrap milestone as complete
- introduce canonical Perception and Action factories
- replace `dispatch`/`says` with `ingestPerception` and `act`
- update runtime CLI and tests to new API
- adjust demo empty-soul to compile
- document `ingestPerception` helper

## Testing
- `cd runtime && npm test`