### PR TITLE
Fix TS compile output

### DIFF
--- a/runtime/test/compile-ts-output.test.js
+++ b/runtime/test/compile-ts-output.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const soulDir = path.resolve('../souls/empty-soul');
+
+test('compiled TypeScript uses .mjs extension', async () => {
+  const tmpBase = await fs.mkdtemp(path.join(os.tmpdir(), 'compile-test-'));
+  const origTmp = process.env.TMPDIR;
+  process.env.TMPDIR = tmpBase;
+  const { loadProcess } = await import('../cli.js');
+  await loadProcess(soulDir);
+  const dirs = await fs.readdir(tmpBase);
+  assert.equal(dirs.length, 1);
+  const files = await fs.readdir(path.join(tmpBase, dirs[0]));
+  process.env.TMPDIR = origTmp;
+  assert.ok(files.some(f => f.endsWith('.mjs')));
+});

--- a/runtime/test/ts-relative-import.test.js
+++ b/runtime/test/ts-relative-import.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const soulDir = path.resolve('../souls/engine-feature-test');
+
+// ensure TypeScript files with relative imports compile correctly
+// and their dependencies use .mjs extension
+
+test('compile TypeScript with relative imports', async () => {
+  const tmpBase = await fs.mkdtemp(path.join(os.tmpdir(), 'rel-compile-'));
+  const origTmp = process.env.TMPDIR;
+  process.env.TMPDIR = tmpBase;
+  const { loadProcess } = await import('../cli.js');
+  await loadProcess(soulDir);
+  const dirs = await fs.readdir(tmpBase);
+  assert.equal(dirs.length, 1);
+  const [dir] = dirs;
+  const stepFiles = await fs.readdir(path.join(tmpBase, dir, 'cognitiveSteps'));
+  process.env.TMPDIR = origTmp;
+  assert.ok(stepFiles.includes('externalDialog.mjs'));
+});
+


### PR DESCRIPTION
## Summary
- compile TypeScript to `.mjs` files so Node treats them as ES modules
- test that compiled TypeScript uses `.mjs` extension
- compile dependencies referenced by TypeScript files
- new test for TypeScript files with relative imports

## Testing
- `cd runtime && npm test` *(fails: Cannot find package 'typescript')*